### PR TITLE
Specify unitx_socket_directories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,10 +36,10 @@ EOF
 
 # Internal start of the server for setup via 'psql'
 # Note: does not listen on external TCP/IP and waits until start finishes
-pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -c password_encryption=scram-sha-256" -w start
+pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -c password_encryption=scram-sha-256 -k /ega" -w start
 
 # Create lega database
-psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname postgres <<-'EOSQL'
+psql -h /ega -v ON_ERROR_STOP=1 --username postgres --no-password --dbname postgres <<-'EOSQL'
      SET TIME ZONE 'UTC';
      CREATE DATABASE lega;
 EOSQL
@@ -53,7 +53,7 @@ DB_FILES=(/etc/ega/initdb.d/main.sql
 for f in "${DB_FILES[@]}"; do # in order
     echo "$0: running $f";
     echo
-    psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname lega -f "$f";
+    psql -h /ega -v ON_ERROR_STOP=1 --username postgres --no-password --dbname lega -f "$f";
     echo
 done
 
@@ -62,7 +62,7 @@ done
 [[ -z "${DB_LEGA_IN_PASSWORD}" ]] && echo 'Environment DB_LEGA_IN_PASSWORD is empty' 1>&2 && exit 1
 [[ -z "${DB_LEGA_OUT_PASSWORD}" ]] && echo 'Environment DB_LEGA_OUT_PASSWORD is empty' 1>&2 && exit 1
 
-psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname lega <<EOSQL
+psql -h /ega -v ON_ERROR_STOP=1 --username postgres --no-password --dbname lega <<EOSQL
      ALTER USER lega_in WITH PASSWORD '${DB_LEGA_IN_PASSWORD}';
      ALTER USER lega_out WITH PASSWORD '${DB_LEGA_OUT_PASSWORD}';
 EOSQL

--- a/pg.conf
+++ b/pg.conf
@@ -7,6 +7,8 @@ max_connections = 100			# (change requires restart)
 
 # - Security and Authentication -
 
+unix_socket_directories = '/ega'
+
 authentication_timeout = 10s		# 1s-600s
 
 ssl = on


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
In kubernetes we get errors like:
```
waiting for server to start....2020-04-05 00:34:56.775 CEST [24] FATAL:  could not create lock file "/var/run/postgresql/.s.PGSQL.5432.lock": Read-only file system
2020-04-05 00:34:56.775 CEST [24] LOG:  database system is shut down
```

We need to change `unix_socket_directories` to `/ega` in order to make this run.
This is also due to that we don't have a volume to /var/run/postgresql` (but that can also be fixed in helm charts.

I think this is a more elegant solution.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. pg_ctl has `-k` option for `/ega`
2. psql has `-h` option for `/ega`
3. added to `pg.conf` `unix_socket_directories`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
`sda-helm` charts for `sda-db` fail to start with persistence on.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

`cat` of file is also a problem in kubernetes as `/tmp` is needed here-document
```
/usr/local/bin/entrypoint.sh: line 31: cannot create temp file for here-document: Read-only file system
```

However that can be fixed by adding a volume mount to `/tmp` in helm charts. A more elegant solution would be files in this repo, but that is for a different PR.