### PR TITLE
Etrypoint fixes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,13 @@ PG_SERVER_KEY=${PG_SERVER_KEY:-${PGVOLUME}/pg.key}
 PG_CA=${PG_CA:-${PGVOLUME}/CA.cert}
 PG_VERIFY_PEER=${PG_VERIFY_PEER:-0}
 
+if [ -n "${PKI_VOLUME_PATH}" ]; then
+# copying the TLS certificates
+    mkdir -p "${PGVOLUME}"/tls
+    cp "${PKI_VOLUME_PATH}"/* "${PGVOLUME}"/tls/
+    chmod 600 "${PGVOLUME}"/tls/*
+fi
+
 if [ ! -e "${PG_SERVER_CERT}" ] || [ ! -e "${PG_SERVER_KEY}" ]; then
 # Generating the SSL certificate + key
 openssl req -x509 -newkey rsa:2048 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ hostssl  all  	    all       all            scram-sha-256   clientcert=${PG_VERI
 EOF
 
 # Copy config file to presistent volume
-cat >> "${PGVOLUME}/pg.conf" <<EOF
+cat > "${PGVOLUME}/pg.conf" <<EOF
 listen_addresses = '*'
 max_connections = 100
 authentication_timeout = 10s


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Since PG has the requirement that the TLS certificated needs to be owned by the postgres user we need to copy service generated certificates to the persistent volume and set the correct permissions.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) If we generate the pg.conf file, do it from a clean slate.
2) If `PKI_VOLUME_PATH` is defined copy the contents into `PGVOLUME/tls` and set the correct permissions.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
